### PR TITLE
fix: Ecommerce broken Index Field Selection

### DIFF
--- a/lib/Db/PimcoreExtensionsTrait.php
+++ b/lib/Db/PimcoreExtensionsTrait.php
@@ -278,7 +278,7 @@ trait PimcoreExtensionsTrait
         $stmt = $this->executeQuery($sql, $params, $types);
         $data = [];
         if ($stmt instanceof Result) {
-            while ($row = $stmt->fetchOne()) {
+            while (($row = $stmt->fetchOne()) || $row !== false) {
                 $data[] = $row;
             }
             $stmt->free();


### PR DESCRIPTION
## Changes in this pull request  
 Resolves #12487
Check if row is false so nullable values do not brake the loop

